### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/0xr0bert/libpamtpmpin/security/code-scanning/1](https://github.com/0xr0bert/libpamtpmpin/security/code-scanning/1)

To fix the problem, explicitly specify a `permissions` block at the workflow or job level, limiting token permissions to only those necessary for this workflow. Since the shown steps merely install build tools, check out code, and build software—none require write access (`contents: write`), only `contents: read` is needed (to allow code checkout). The most maintainable way to achieve this is to add `permissions: contents: read` at the root of the workflow, so all jobs default to least privilege unless a specific job needs more. The `permissions` block should be added after the workflow `name` and before `on`. This does not affect workflow behavior but improves security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
